### PR TITLE
add dbusmenu support via libdbusmenu

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -45,6 +45,14 @@ AC_ARG_ENABLE([warning-flags],
 	AS_HELP_STRING([--enable-warning-flags], [enable extra compiler warning flags]),
 	[warningflags=$enableval], [warningflags=no])
 
+AC_ARG_ENABLE([dbusmenu],
+	AS_HELP_STRING([--enable-dbusmenu], [enable extra dbusmenu functionality via libdbusmenu]),
+	[dbusmenu=$enableval], [dbusmenu=no])
+
+AC_ARG_WITH([dbusmenu-gtk-version],
+	AS_HELP_STRING([--with-dbusmenu-gtk-version], [Select libdbusmenu-gtk version to be built against if dbusmenu support enabled. Possible values: 2,3. Default: 3 ]),
+	[dbusmenugtkversion=$enableval], [dbusmenugtkversion=3])
+
 # Checks for libraries.
 PKG_CHECK_MODULES(GOBJECT, [gobject-2.0], , AC_MSG_ERROR([GLib/GObject is required]))
 PKG_CHECK_MODULES(GIO, [gio-2.0], , AC_MSG_ERROR([GLib/GIO is required]))
@@ -137,6 +145,49 @@ else
     AC_MSG_RESULT([no])
 fi
 
+if test "x$dbusmenu" = "xyes"; then
+    if test "x$dbusmenugtkversion" = "x2"; then
+        AC_MSG_NOTICE([dbusmenu support will be built against dbusmenu-gtk (gtk2)])
+    elif test "x$dbusmenugtkversion" = "x3"; then
+        AC_MSG_NOTICE([dbusmenu support will be built against dbusmenu-gtk3 (gtk3)])
+    else
+        dbusmenugtkversion=3;
+        AC_MSG_NOTICE([dbusmenu support will be built against dbusmenu-gtk3 (gtk3)])
+    fi
+
+    if test "x$dbusmenugtkversion" = "x2"; then
+        PKG_CHECK_MODULES(DBUSMENU, [dbusmenu-glib-0.4 dbusmenu-gtk-0.4], [
+            DEP_PACKAGES="${DEP_PACKAGES} dbusmenu-glib-0.4 dbusmenu-gtk-0.4"
+        ], [
+            AC_MSG_WARN([dbusmenu-glib and dbusmenu-gtk are required for dbusmenu support])
+            dbusmenu=no
+        ])
+    elif test "x$dbusmenugtkversion" = "x3"; then
+        PKG_CHECK_MODULES(DBUSMENU, [dbusmenu-glib-0.4 dbusmenu-gtk3-0.4], [
+            DEP_PACKAGES="${DEP_PACKAGES} dbusmenu-glib-0.4 dbusmenu-gtk3-0.4"
+        ], [
+            AC_MSG_WARN([dbusmenu-glib and dbusmenu-gtk3 are required for dbusmenu support])
+            dbusmenu=no
+        ])
+    fi
+fi
+
+AC_MSG_CHECKING([for dbusmenu support])
+if test "x$dbusmenu" = "xyes"; then
+    AC_MSG_RESULT([yes])
+    DEP_CFLAGS="$DEP_CFLAGS $DBUSMENU_CFLAGS"
+    DEP_LIBS="$DEP_LIBS $DBUSMENU_LIBS"
+    AC_SUBST(DEP_PACKAGES)
+    AC_SUBST(DEP_CFLAGS)
+    AC_SUBST(DEP_LIBS)
+    AC_DEFINE([USE_DBUSMENU], , [Use dbusmenu])
+    dbusmenu="will be built against GTK ${dbusmenugtkversion}"
+else
+    AC_MSG_RESULT([no])
+    dbusmenu=no
+fi
+AM_CONDITIONAL(USE_DBUSMENU, test "x$dbusmenu" != "xno")
+
 AC_CONFIG_FILES([Makefile statusnotifier.pc example/Makefile
                  docs/reference/Makefile docs/reference/version.xml])
 AC_OUTPUT
@@ -150,9 +201,11 @@ echo "
 
    build html documentation : ${enable_gtk_doc}
    example                  : ${enable_example}
+   dbusmenu                 : ${dbusmenu}
 
  Install paths:
    binaries                 : $(eval echo $(eval echo ${bindir}))
+   libraries                : $(eval echo $(eval echo ${libdir}))
    documentation            : $(eval echo $(eval echo ${docdir}))
    man pages                : $(eval echo $(eval echo ${mandir}))
 "

--- a/configure.ac
+++ b/configure.ac
@@ -159,15 +159,14 @@ if test "x$dbusmenu" = "xyes"; then
         PKG_CHECK_MODULES(DBUSMENU, [dbusmenu-glib-0.4 dbusmenu-gtk-0.4], [
             DEP_PACKAGES="${DEP_PACKAGES} dbusmenu-glib-0.4 dbusmenu-gtk-0.4"
         ], [
-            AC_MSG_WARN([dbusmenu-glib and dbusmenu-gtk are required for dbusmenu support])
-            dbusmenu=no
+            AC_MSG_ERROR([dbusmenu-glib and dbusmenu-gtk are required for dbusmenu support])
         ])
+
     elif test "x$dbusmenugtkversion" = "x3"; then
         PKG_CHECK_MODULES(DBUSMENU, [dbusmenu-glib-0.4 dbusmenu-gtk3-0.4], [
             DEP_PACKAGES="${DEP_PACKAGES} dbusmenu-glib-0.4 dbusmenu-gtk3-0.4"
         ], [
-            AC_MSG_WARN([dbusmenu-glib and dbusmenu-gtk3 are required for dbusmenu support])
-            dbusmenu=no
+            AC_MSG_ERROR([dbusmenu-glib and dbusmenu-gtk3 are required for dbusmenu support])
         ])
     fi
 fi

--- a/docs/reference/statusnotifier-sections.txt
+++ b/docs/reference/statusnotifier-sections.txt
@@ -34,6 +34,8 @@ status_notifier_set_tooltip_title
 status_notifier_get_tooltip_title
 status_notifier_set_tooltip_body
 status_notifier_get_tooltip_body
+status_notifier_set_context_menu
+status_notifier_get_context_menu
 status_notifier_register
 status_notifier_get_state
 <SUBSECTION Standard>

--- a/docs/reference/statusnotifier-sections.txt
+++ b/docs/reference/statusnotifier-sections.txt
@@ -36,8 +36,6 @@ status_notifier_set_tooltip_body
 status_notifier_get_tooltip_body
 status_notifier_set_context_menu
 status_notifier_get_context_menu
-status_notifier_set_item_is_menu
-status_notifier_get_item_is_menu
 status_notifier_register
 status_notifier_get_state
 <SUBSECTION Standard>

--- a/docs/reference/statusnotifier-sections.txt
+++ b/docs/reference/statusnotifier-sections.txt
@@ -36,6 +36,8 @@ status_notifier_set_tooltip_body
 status_notifier_get_tooltip_body
 status_notifier_set_context_menu
 status_notifier_get_context_menu
+status_notifier_set_item_is_menu
+status_notifier_get_item_is_menu
 status_notifier_register
 status_notifier_get_state
 <SUBSECTION Standard>

--- a/example/sn-example.c
+++ b/example/sn-example.c
@@ -54,7 +54,6 @@ struct config
 #ifdef USE_DBUSMENU
     gboolean menu;
 #endif
-    gboolean is_menu;
 };
 
 static void
@@ -127,7 +126,6 @@ GtkMenu *create_menu (StatusNotifier *sn, GMainLoop *loop)
     gtk_menu_attach (menu, item, 0, 1, i, i + 1);
     ++i;
 
-    g_object_ref_sink (menu);
     return menu;
 }
 
@@ -312,8 +310,6 @@ parse_cmdline (struct config *cfg, gint *argc, gchar **argv[], GError **error)
         { "dbus-menu",          'm',    0, G_OPTION_ARG_NONE,     &cfg->menu,
             "Whether menu should be exposed via dbusmenu or not", NULL },
 #endif
-        { "is-menu",            'M',    0, G_OPTION_ARG_NONE,     &cfg->is_menu,
-            "Whether application has only menu or it has window", NULL },
         { NULL }
     };
     GOptionGroup *group;
@@ -377,7 +373,6 @@ main (gint argc, gchar *argv[])
     if (cfg.tooltip_body)
         status_notifier_set_tooltip_body (sn, cfg.tooltip_body);
 
-    status_notifier_set_item_is_menu (sn, cfg.is_menu);
 #ifdef USE_DBUSMENU
     if (cfg.menu)
         status_notifier_set_context_menu (sn, (GtkWidget *) create_menu(sn, loop));

--- a/example/sn-example.c
+++ b/example/sn-example.c
@@ -22,6 +22,7 @@
 
 #include "config.h"
 
+#include <glib.h>
 #include <gtk/gtk.h>
 #include <statusnotifier.h>
 #include <string.h>
@@ -68,6 +69,7 @@ GtkMenu *get_menu (StatusNotifier *sn, GMainLoop *loop)
     GtkWidget *item;
     guint i;
     StatusNotifierStatus status;
+    GSList *group = NULL;
 
     if (menu)
         return menu;
@@ -78,33 +80,40 @@ GtkMenu *get_menu (StatusNotifier *sn, GMainLoop *loop)
     g_object_get (sn, "status", &status, NULL);
 
     i = 0;
-    item = gtk_check_menu_item_new_with_label ("Passive");
+
+    item = gtk_radio_menu_item_new_with_label (group, "Passive");
+    group = gtk_radio_menu_item_get_group ((GtkRadioMenuItem *) item);
     if (status == STATUS_NOTIFIER_STATUS_PASSIVE)
         gtk_check_menu_item_set_active ((GtkCheckMenuItem *) item, TRUE);
     g_object_set_data ((GObject *) item,
             "sn-status", GUINT_TO_POINTER (STATUS_NOTIFIER_STATUS_PASSIVE));
-    g_signal_connect (item, "activate", (GCallback) set_status, sn);
     gtk_widget_show (item);
     gtk_menu_attach (submenu, item, 0, 1, i, i + 1);
     ++i;
-    item = gtk_check_menu_item_new_with_label ("Active");
+    item = gtk_radio_menu_item_new_with_label (group, "Active");
+    group = gtk_radio_menu_item_get_group ((GtkRadioMenuItem *) item);
     if (status == STATUS_NOTIFIER_STATUS_ACTIVE)
         gtk_check_menu_item_set_active ((GtkCheckMenuItem *) item, TRUE);
     g_object_set_data ((GObject *) item,
             "sn-status", GUINT_TO_POINTER (STATUS_NOTIFIER_STATUS_ACTIVE));
-    g_signal_connect (item, "activate", (GCallback) set_status, sn);
     gtk_widget_show (item);
     gtk_menu_attach (submenu, item, 0, 1, i, i + 1);
     ++i;
-    item = gtk_check_menu_item_new_with_label ("Needs attention");
+    item = gtk_radio_menu_item_new_with_label (group, "Needs attention");
+    group = gtk_radio_menu_item_get_group ((GtkRadioMenuItem *) item);
     if (status == STATUS_NOTIFIER_STATUS_NEEDS_ATTENTION)
         gtk_check_menu_item_set_active ((GtkCheckMenuItem *) item, TRUE);
     g_object_set_data ((GObject *) item,
             "sn-status", GUINT_TO_POINTER (STATUS_NOTIFIER_STATUS_NEEDS_ATTENTION));
-    g_signal_connect (item, "activate", (GCallback) set_status, sn);
     gtk_widget_show (item);
     gtk_menu_attach (submenu, item, 0, 1, i, i + 1);
     ++i;
+
+    void radio_set_cb (gpointer item, gpointer data)
+    {
+        g_signal_connect (item, "activate", (GCallback) set_status, sn);
+    }
+    g_slist_foreach (group, &radio_set_cb, NULL);
 
     i = 0;
     item = gtk_menu_item_new_with_label ("Status");

--- a/example/sn-example.c
+++ b/example/sn-example.c
@@ -62,17 +62,14 @@ set_status (GObject *item, StatusNotifier *sn)
     status_notifier_set_status (sn, GPOINTER_TO_UINT (g_object_get_data (item, "sn-status")));
 }
 
-GtkMenu *get_menu (StatusNotifier *sn, GMainLoop *loop)
+GtkMenu *create_menu (StatusNotifier *sn, GMainLoop *loop)
 {
-    static GtkMenu *menu = NULL;
+    GtkMenu *menu;
     GtkMenu *submenu;
     GtkWidget *item;
     guint i;
     StatusNotifierStatus status;
     GSList *group = NULL;
-
-    if (menu)
-        return menu;
 
     menu = (GtkMenu *) gtk_menu_new ();
     submenu = (GtkMenu *) gtk_menu_new ();
@@ -134,7 +131,11 @@ GtkMenu *get_menu (StatusNotifier *sn, GMainLoop *loop)
 static gboolean
 sn_menu (StatusNotifier *sn, gint x, gint y, GMainLoop *loop)
 {
-    GtkMenu *menu = get_menu(sn, loop);
+    static GtkMenu *menu = NULL;
+    if (!menu) {
+        menu = create_menu (sn, loop);
+        g_object_ref (menu);
+    }
 
     gtk_menu_popup (menu, NULL, NULL, NULL, NULL, 0, gtk_get_current_event_time ());
     return TRUE;
@@ -372,7 +373,7 @@ main (gint argc, gchar *argv[])
 
 #ifdef USE_DBUSMENU
     if (cfg.menu)
-        status_notifier_set_context_menu (sn, (GtkWidget *) get_menu(sn, loop));
+        status_notifier_set_context_menu (sn, (GtkWidget *) create_menu(sn, loop));
     else
         g_signal_connect (sn, "context-menu", (GCallback) sn_menu, loop);
 #else

--- a/src/interfaces.h
+++ b/src/interfaces.h
@@ -65,7 +65,6 @@ static const gchar item_xml[] =
 #ifdef USE_DBUSMENU
     "       <property name='Menu' type='o' access='read' />"
 #endif
-    "       <property name='ItemIsMenu' type='b' access='read' />"
     "       <method name='ContextMenu'>"
     "           <arg name='x' type='i' direction='in' />"
     "           <arg name='y' type='i' direction='in' />"

--- a/src/interfaces.h
+++ b/src/interfaces.h
@@ -62,6 +62,9 @@ static const gchar item_xml[] =
     "       <property name='AttentionIconPixmap' type='(iiay)' access='read' />"
     "       <property name='AttentionMovieName' type='s' access='read' />"
     "       <property name='ToolTip' type='(s(iiay)ss)' access='read' />"
+#ifdef USE_DBUSMENU
+    "       <property name='Menu' type='o' access='read' />"
+#endif
     "       <method name='ContextMenu'>"
     "           <arg name='x' type='i' direction='in' />"
     "           <arg name='y' type='i' direction='in' />"

--- a/src/interfaces.h
+++ b/src/interfaces.h
@@ -65,6 +65,7 @@ static const gchar item_xml[] =
 #ifdef USE_DBUSMENU
     "       <property name='Menu' type='o' access='read' />"
 #endif
+    "       <property name='ItemIsMenu' type='b' access='read' />"
     "       <method name='ContextMenu'>"
     "           <arg name='x' type='i' direction='in' />"
     "           <arg name='y' type='i' direction='in' />"

--- a/src/statusnotifier.c
+++ b/src/statusnotifier.c
@@ -99,7 +99,6 @@ enum
 #ifdef USE_DBUSMENU
     PROP_MENU,
 #endif
-    PROP_IS_MENU,
     PROP_WINDOW_ID,
 
     PROP_STATE,
@@ -160,7 +159,6 @@ struct _StatusNotifierPrivate
     DbusmenuServer *menuservice;
     GtkWidget  *menu;
 #endif
-    gboolean is_menu;
     GDBusConnection *dbus_conn;
     GError *dbus_err;
 };
@@ -471,23 +469,6 @@ status_notifier_class_init (StatusNotifierClass *klass)
                 G_PARAM_READWRITE);
 #endif
 
-     /**
-     * StatusNotifier:item-is-menu:
-     *
-     * Whether this appliaction has main window or not.
-     * If this is set to true then no activate signals will be emmited.
-     * Instead, when LMB pressed, "context-menu" will be emmited.
-     * If there is a setuped context #StatusNotifier:menu, then
-     * it will be shown istead of "context-menu" signal emition.
-     * 
-     * This behavior at least supported by KDE.
-     */
-    status_notifier_props[PROP_IS_MENU] =
-        g_param_spec_boolean ("item-is-menu", "item-is-menu",
-                "Whether this appliaction has no main window or not.",
-                FALSE,
-                G_PARAM_READWRITE);
-
     /**
      * StatusNotifier:window-id:
      *
@@ -729,9 +710,6 @@ status_notifier_set_property (GObject            *object,
             status_notifier_set_context_menu (sn, g_value_get_object (value));
             break;
 #endif
-        case PROP_IS_MENU:
-            status_notifier_set_item_is_menu (sn, g_value_get_boolean (value));
-            break;
         case PROP_WINDOW_ID:
             status_notifier_set_window_id (sn, g_value_get_uint (value));
         default:
@@ -809,9 +787,6 @@ status_notifier_get_property (GObject            *object,
             g_value_set_object (value, status_notifier_get_context_menu (sn));
             break;
 #endif
-        case PROP_IS_MENU:
-            g_value_set_boolean (value, status_notifier_get_item_is_menu (sn));
-            break;
         case PROP_WINDOW_ID:
             g_value_set_uint (value, priv->window_id);
         case PROP_STATE:
@@ -1714,10 +1689,6 @@ get_prop (GDBusConnection        *conn,
             return g_variant_new ("o", "/NO_DBUSMENU");
     }
 #endif
-    else if (!g_strcmp0 (property, "ItemIsMenu"))
-    {
-        return g_variant_new("b", priv->is_menu);
-    }
 
     g_return_val_if_reached (NULL);
 }
@@ -2104,39 +2075,3 @@ status_notifier_get_context_menu (StatusNotifier          *sn)
     return priv->menu;
 }
 #endif
-
-/**
- * status_notifier_set_item_is_menu:
- * @sn: A #StatusNotifier
- * @is_menu: #boolean whether this application has only menu or not
- * 
- * See #StatusNotifier:item-is-menu for description.
- */
-void
-status_notifier_set_item_is_menu (StatusNotifier          *sn,
-                                  gboolean                is_menu)
-{
-    StatusNotifierPrivate *priv;
-
-    g_return_if_fail (IS_STATUS_NOTIFIER (sn));
-    priv = sn->priv;
-
-    priv->is_menu = is_menu;
-}
-
-/**
- * status_notifier_get_item_is_menu:
- * @sn: A #StatusNotifier
- * 
- * Returns: whether this application has only menu or not
- */
-gboolean
-status_notifier_get_item_is_menu (StatusNotifier          *sn)
-{
-    StatusNotifierPrivate *priv;
-
-    g_return_if_fail (IS_STATUS_NOTIFIER (sn));
-    priv = sn->priv;
-
-    return priv->is_menu;
-}

--- a/src/statusnotifier.h
+++ b/src/statusnotifier.h
@@ -27,6 +27,9 @@
 #include <glib-object.h>
 #include <gio/gio.h>
 #include <gdk-pixbuf/gdk-pixbuf.h>
+#ifdef USE_DBUSMENU
+#include <gtk/gtk.h>
+#endif
 
 G_BEGIN_DECLS
 
@@ -298,6 +301,13 @@ void                    status_notifier_register (
                                             StatusNotifier          *sn);
 StatusNotifierState     status_notifier_get_state (
                                             StatusNotifier          *sn);
+#ifdef USE_DBUSMENU
+void                    status_notifier_set_context_menu (
+                                            StatusNotifier          *sn,
+                                            GtkWidget               *menu);
+GtkWidget *             status_notifier_get_context_menu (
+                                            StatusNotifier          *sn);
+#endif
 
 G_END_DECLS
 

--- a/src/statusnotifier.h
+++ b/src/statusnotifier.h
@@ -308,11 +308,6 @@ void                    status_notifier_set_context_menu (
 GtkWidget *             status_notifier_get_context_menu (
                                             StatusNotifier          *sn);
 #endif
-void                    status_notifier_set_item_is_menu (
-                                            StatusNotifier          *sn,
-                                            gboolean                is_menu);
-gboolean                status_notifier_get_item_is_menu (
-                                            StatusNotifier          *sn);
 
 G_END_DECLS
 

--- a/src/statusnotifier.h
+++ b/src/statusnotifier.h
@@ -308,6 +308,11 @@ void                    status_notifier_set_context_menu (
 GtkWidget *             status_notifier_get_context_menu (
                                             StatusNotifier          *sn);
 #endif
+void                    status_notifier_set_item_is_menu (
+                                            StatusNotifier          *sn,
+                                            gboolean                is_menu);
+gboolean                status_notifier_get_item_is_menu (
+                                            StatusNotifier          *sn);
 
 G_END_DECLS
 


### PR DESCRIPTION
Adds two new functions:

status_notifier_set_context_menu
status_notifier_get_context_menu

new ./configure options:
--enable-dbusmenu
--with-dbusmenu-gtk-version=[2,3]

the only problem, i don't know how to make this functions optional in documentation.