### PR TITLE
Fix gtk-doc build with libtool

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -44,6 +44,17 @@ AC_CONFIG_AUX_DIR([build-aux])
 AM_INIT_AUTOMAKE([-Wall -Werror -Wno-portability foreign silent-rules subdir-objects])
 AM_SILENT_RULES([yes])
 
+# Checks for programs.
+AC_PROG_CC
+AM_PROG_AR
+
+LT_INIT
+LIB_VERSION_INFO="lib_current:lib_revision:lib_age"
+AC_SUBST(LIB_VERSION_INFO)
+
+GIR_VERSION="gir_version"
+AC_SUBST(GIR_VERSION)
+
 # Option to make doc
 m4_ifdef([GTK_DOC_CHECK], [
 GTK_DOC_CHECK([1.19],[--flavour no-tmpl])
@@ -56,17 +67,6 @@ AC_PATH_PROG([XSLTPROC], [xsltproc])
 ],[
 AM_CONDITIONAL([ENABLE_GTK_DOC], false)
 ])
-
-# Checks for programs.
-AC_PROG_CC
-AM_PROG_AR
-
-LT_INIT
-LIB_VERSION_INFO="lib_current:lib_revision:lib_age"
-AC_SUBST(LIB_VERSION_INFO)
-
-GIR_VERSION="gir_version"
-AC_SUBST(GIR_VERSION)
 
 # Option for example
 AC_ARG_ENABLE([example],

--- a/docs/reference/Makefile.am
+++ b/docs/reference/Makefile.am
@@ -70,7 +70,7 @@ expand_content_files=
 # e.g. GTKDOC_CFLAGS=-I$(top_srcdir) -I$(top_builddir) $(GTK_DEBUG_FLAGS)
 # e.g. GTKDOC_LIBS=$(top_builddir)/gtk/$(gtktargetlib)
 GTKDOC_CFLAGS=$(DEP_CFLAGS)
-GTKDOC_LIBS=$(DEP_LIBS) $(top_builddir)/.libs/libstatusnotifier.a
+GTKDOC_LIBS=$(top_builddir)/.libs/libstatusnotifier.la
 
 # This includes the standard gtk-doc make rules, copied by gtkdocize.
 include $(top_srcdir)/gtk-doc.make


### PR DESCRIPTION
LT_INIT should be introduced before GTK_DOC_CHECK in configure.ac to
make gtk-doc build to use libtool.

This also fixes the gtk-doc build with --disable-static.

Patch by @wally-mageia, tested with http://svnweb.mageia.org/packages?view=revision&revision=1092470